### PR TITLE
Switcher renamed to Manager for clarity

### DIFF
--- a/BrackeysJam2/Assets/Scripts/PowerUps/PowerUpManager.cs
+++ b/BrackeysJam2/Assets/Scripts/PowerUps/PowerUpManager.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 using System.Collections;
 
-public class PowerUpSwitcher : MonoBehaviour
+public class PowerUpManager : MonoBehaviour
 {
     [HideInInspector] public bool isUsingSpeedPowerUp=false;
     [HideInInspector] public bool isUsingDashPowerUp=false;

--- a/BrackeysJam2/Assets/Scripts/PowerUps/PowerUpManager.cs.meta
+++ b/BrackeysJam2/Assets/Scripts/PowerUps/PowerUpManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 54c5c128fd7df2a4ba31baa6aa3fca1b

--- a/BrackeysJam2/Assets/Scripts/PowerUps/PowerUpSwitcher.cs.meta
+++ b/BrackeysJam2/Assets/Scripts/PowerUps/PowerUpSwitcher.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: e42c7cc8334c0254782594eeda2b94a4


### PR DESCRIPTION
PowerUpSwitcher is renamed to PowerUpManager as it manages the selected PowerUp