### PR TITLE
Adding tilemapSO and its custom editor

### DIFF
--- a/PetRockToPit/Assets/Editor/TileMapDataEditor.cs
+++ b/PetRockToPit/Assets/Editor/TileMapDataEditor.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+[CustomEditor(typeof(NewTilemapData))]
+public class TileMapDataEditor : Editor
+{
+    
+    public Tilemap platformTilemap;
+    public Tilemap obstacleTilemap;
+    public Tilemap levelEndTilemap;
+    public Tilemap moveableObjectTilemap;
+    public Tilemap buttonTilemap;
+
+
+
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+
+        DrawDefaultInspector();
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("Tilemap export tools", EditorStyles.boldLabel);
+
+        platformTilemap = (Tilemap)EditorGUILayout.ObjectField("PlatForm Tilemap", platformTilemap, typeof(Tilemap), true);
+        obstacleTilemap = (Tilemap)EditorGUILayout.ObjectField("Obstacle Tilemap", obstacleTilemap, typeof(Tilemap), true);
+        levelEndTilemap = (Tilemap)EditorGUILayout.ObjectField("Level End Tilemap", levelEndTilemap, typeof(Tilemap), true);
+        moveableObjectTilemap = (Tilemap)EditorGUILayout.ObjectField("Moveable Object Tilemap", moveableObjectTilemap, typeof(Tilemap), true);
+        buttonTilemap = (Tilemap)EditorGUILayout.ObjectField("Button Tilemap", buttonTilemap, typeof(Tilemap), true);
+
+
+        if (GUILayout.Button("Export scene TileMaps to SO"))
+        {
+            ExportTiles((NewTilemapData)target);
+        }
+
+        
+    }
+
+    private void ExportTiles(NewTilemapData data)
+    {
+        data.platformTiles.Clear();
+        data.obstacleTiles.Clear();
+        data.levelEndTiles.Clear();
+        data.moveableObjectTiles.Clear();
+        data.buttonTiles.Clear();
+        
+
+        
+        if(platformTilemap)ExportTilemap(platformTilemap, data.platformTiles, data.tilePalette);
+
+        if(obstacleTilemap)ExportTilemap(obstacleTilemap, data.obstacleTiles, data.tilePalette);
+
+        if(levelEndTilemap)ExportTilemap(levelEndTilemap, data.levelEndTiles, data.tilePalette);
+
+        if(moveableObjectTilemap)ExportTilemap(moveableObjectTilemap, data.moveableObjectTiles, data.tilePalette);
+
+        if(buttonTilemap) ExportTilemap(buttonTilemap, data.buttonTiles, data.tilePalette);
+        
+        EditorUtility.SetDirty(data);
+        Debug.Log("Exported Tilemap data to SO");
+    }
+
+    private void ExportTilemap(Tilemap tilemap, List<NewTilemapData.TileData> tilesList, TileBase[] tilePalette)
+    {
+        if (tilemap == null || tilePalette == null) return;
+        BoundsInt bounds = tilemap.cellBounds;
+        foreach (var pos in bounds.allPositionsWithin)
+        {
+            TileBase tile = tilemap.GetTile(pos);
+            if (tile != null)
+            {
+                int typeID = System.Array.IndexOf(tilePalette, tile);
+                tilesList.Add(new NewTilemapData.TileData { position = pos, tileTypeID = typeID });
+            }
+        }
+    }
+}

--- a/PetRockToPit/Assets/Scripts/ScriptableObjects/NewTilemapData.cs
+++ b/PetRockToPit/Assets/Scripts/ScriptableObjects/NewTilemapData.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Tilemaps;
+
+[CreateAssetMenu(fileName = "NewTilemapData", menuName = "Scriptable Objects/NewTilemapData")]
+public class NewTilemapData : ScriptableObject
+{
+    public List<TileData> platformTiles = new List<TileData>();
+    public List<TileData> levelEndTiles = new List<TileData>();
+    public List<TileData> obstacleTiles = new List<TileData>();
+    public List<TileData> moveableObjectTiles = new List<TileData>();
+    public List<TileData> buttonTiles = new List<TileData>();
+    
+    public TileBase[] tilePalette;
+
+    [System.Serializable]
+    public struct TileData
+    {
+        public Vector3Int position;
+        public int tileTypeID; // Map this ID to an actual TileBase
+    }
+}


### PR DESCRIPTION
TilemapSO holds the tilemap data of a specified level
The custom editor is used to update the scene tilemap data into the Scriptable Object.